### PR TITLE
Fix/nano support

### DIFF
--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -263,7 +263,7 @@ def _is_nanoserver(client):
 
        Using the powershell code from here: https://goo.gl/UD27SK
     """
-    server_level_key = (r'HKLM:Software\Microsoft\Windows NT\CurrentVersion'
+    server_level_key = (r'HKLM:\Software\Microsoft\Windows NT\CurrentVersion'
                         r'\Server\ServerLevels')
 
     cmd = r'Test-Path "{}"'.format(server_level_key)
@@ -274,7 +274,7 @@ def _is_nanoserver(client):
     if path_exists == "False":
         return False
 
-    cmd = r'(Get-ItemProperty {}).NanoServer'.format(server_level_key)
+    cmd = r'(Get-ItemProperty "{}").NanoServer'.format(server_level_key)
     nanoserver_property, _, _ = client.run_command_with_retry(
         cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
         command_type=util.POWERSHELL)

--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -301,7 +301,7 @@ def _get_product_type(client):
     :param client:
         A Windows Client.
     """
-    cmd = r"(Get-WmiObject -Class Win32_OperatingSystem).producttype"
+    cmd = r"(Get-CimInstance -Class Win32_OperatingSystem).producttype"
     product_type, _, _ = client.run_command_with_retry(
         cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
         command_type=util.POWERSHELL)

--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -279,7 +279,7 @@ def _is_nanoserver(client):
         cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
         command_type=util.POWERSHELL)
 
-    return nanoserver_property == "1"
+    return len(nanoserver_property) > 0 and nanoserver_property[0] == "1"
 
 
 def _get_major_version(client):

--- a/argus/introspection/cloud/windows.py
+++ b/argus/introspection/cloud/windows.py
@@ -126,7 +126,7 @@ def _get_nic_details(details):
 def get_cbinit_dir(execute_function):
     """Get the location of cloudbase-init from the instance."""
     stdout = execute_function(
-        '(Get-WmiObject  Win32_OperatingSystem).'
+        '(Get-CimInstance Win32_OperatingSystem).'
         'OSArchitecture', command_type=util.POWERSHELL)
     architecture = stdout.strip()
 


### PR DESCRIPTION
I fix some paths for Windows Nano, used `Get-CimInstance` in some places to avoid `Get-WmiObject`. This pach also refactored  the `wait_boot_completion` because the logic was implemented in two places.
