### PR TITLE
Fix copy_file method in the client

### DIFF
--- a/argus/client/windows.py
+++ b/argus/client/windows.py
@@ -142,7 +142,7 @@ class WinRemoteClient(base.BaseClient):
         commands = []
         for command in _base64_read_file(filepath):
             remote_command = (
-                "{content} >> {remote_destination}"
+                "{content} >> '{remote_destination}'"
                 .format(content=get_string_cmd.format(command),
                         remote_destination=remote_destination))
 


### PR DESCRIPTION
The copy_file could not function if a space was
present in the destination path.

Signed-off-by: Micu Matei-Marius mmicu@cloudbasesolutions.com
