### PR TITLE
Improve the test_mtu logic 

### DIFF
--- a/argus/backends/tempest/tempest_backend.py
+++ b/argus/backends/tempest/tempest_backend.py
@@ -22,6 +22,7 @@ import six
 from argus.backends import base as base_backend
 from argus.backends import windows
 from argus.backends.tempest import manager as api_manager
+from argus import exceptions
 from argus import util
 
 with util.restore_excepthook():
@@ -101,6 +102,13 @@ class BaseTempestBackend(base_backend.CloudBackend):
         self._manager.floating_ips_client.associate_floating_ip_to_server(
             floating_ip['ip'], self.internal_instance_id())
         return floating_ip
+
+    def _get_mtu(self):
+        try:
+            return self._manager.primary_credentials().network["mtu"]
+        except Exception as exc:
+            raise exceptions.ArgusError('Could not get the MTU from the '
+                                        'tempest backend: %s' % exc)
 
     @property
     def __get_id_tenant_network(self):

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -304,7 +304,7 @@ class TestsBaseSmoke(TestCreatedUser,
     def test_mtu(self):
         # Verify that we have the expected MTU in the instance.
         mtu = self._introspection.get_instance_mtu()
-        expected_mtu = _get_dhcp_value('26')
+        expected_mtu = str(self._backend._get_mtu())
         self.assertEqual(expected_mtu, mtu)
 
     def test_user_belongs_to_group(self):


### PR DESCRIPTION
The test that checks if the MTU has been set correctly is currently
depending on a hardcoded value from neutron conf, a better approach would
be to get the MTU value from the network created by tempest.
