### PR TITLE
Ignore the certificate when connecting via HTTPS

### DIFF
--- a/argus/client/windows.py
+++ b/argus/client/windows.py
@@ -120,6 +120,7 @@ class WinRemoteClient(base.BaseClient):
                                  transport='plaintext',
                                  username=self._username,
                                  password=self._password,
+                                 server_cert_validation='ignore',
                                  cert_pem=self._cert_pem,
                                  cert_key_pem=self._cert_key)
 


### PR DESCRIPTION
Adds a new field that is necessary when connecting via HTTPS on port 5986,
so that the certificate verification won't fail.
