### PR TITLE
Add getter method for MTU in the APIManager

### DIFF
--- a/argus/backends/heat/heat_backend.py
+++ b/argus/backends/heat/heat_backend.py
@@ -278,6 +278,9 @@ class BaseHeatBackend(base.CloudBackend):
         """Get the image object by its reference id."""
         return self._manager.compute_images_client.show_image(self._conf.openstack.image_ref)
 
+    def get_mtu(self):
+        return self._manager.get_mtu()
+
 
 class WindowsHeatBackend(windows.WindowsBackendMixin, BaseHeatBackend):
     """Heat backend tailored to work with Windows platforms."""

--- a/argus/backends/tempest/manager.py
+++ b/argus/backends/tempest/manager.py
@@ -17,6 +17,7 @@ import contextlib
 import os
 import tempfile
 
+from argus import exceptions
 from argus import util
 
 with util.restore_excepthook():
@@ -155,6 +156,14 @@ class APIManager(object):
     def instance_server(self, instance_id):
         """Get more details about the given instance id."""
         return self.servers_client.show_server(instance_id)['server']
+
+    def get_mtu(self):
+        """Get the MTU value, from the backend."""
+        try:
+            return self.primary_credentials().network["mtu"]
+        except Exception as exc:
+            raise exceptions.ArgusError('Could not get the MTU from the '
+                                        'tempest backend: %s' % exc)
 
 
 class Keypair(object):

--- a/argus/backends/tempest/tempest_backend.py
+++ b/argus/backends/tempest/tempest_backend.py
@@ -22,7 +22,6 @@ import six
 from argus.backends import base as base_backend
 from argus.backends import windows
 from argus.backends.tempest import manager as api_manager
-from argus import exceptions
 from argus import util
 
 with util.restore_excepthook():
@@ -103,12 +102,8 @@ class BaseTempestBackend(base_backend.CloudBackend):
             floating_ip['ip'], self.internal_instance_id())
         return floating_ip
 
-    def _get_mtu(self):
-        try:
-            return self._manager.primary_credentials().network["mtu"]
-        except Exception as exc:
-            raise exceptions.ArgusError('Could not get the MTU from the '
-                                        'tempest backend: %s' % exc)
+    def get_mtu(self):
+        return self._manager.get_mtu()
 
     @property
     def __get_id_tenant_network(self):

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -300,11 +300,10 @@ class TestsBaseSmoke(TestCreatedUser,
         self.assertEqual(set(self._backend.public_key().splitlines()),
                          set(public_keys))
 
-    @test_util.skip_unless_dnsmasq_configured
     def test_mtu(self):
         # Verify that we have the expected MTU in the instance.
         mtu = self._introspection.get_instance_mtu()
-        expected_mtu = str(self._backend._get_mtu())
+        expected_mtu = str(self._backend.get_mtu())
         self.assertEqual(expected_mtu, mtu)
 
     def test_user_belongs_to_group(self):


### PR DESCRIPTION
Adds the getter for MTU in the APIManager, exposing it to the tempest and
heat backend, since both use it in the tests for checking if the MTU value
has been set.
