### PR TITLE
Restructure the licensing logic

### DIFF
--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -128,9 +128,9 @@ class WindowsActionManager(base.BaseActionManager):
         LOG.info("Run the downloaded installation script "
                  "using the installer %r with service %r.",
                  installer, service_type)
-
-        parameters = '-serviceType {} -installer {}'.format(service_type,
-                                                            installer)
+        activation = self._conf.cloudbaseinit.activate_windows
+        parameters = ('-serviceType {} -installer {} -activation {}'
+                      .format(service_type, installer, activation))
         try:
             self.execute_powershell_resource_script(
                 resource_location='windows/installCBinit.ps1',

--- a/argus/config.py
+++ b/argus/config.py
@@ -85,12 +85,12 @@ class ConfigurationParser(object):
     def cloudbaseinit(self):
         cloudbaseinit = collections.namedtuple(
             'cloudbaseinit',
-            'created_user group')
+            'created_user group activate_windows')
 
         group = self._parser.get('cloudbaseinit', 'group')
         created_user = self._parser.get('cloudbaseinit', 'created_user')
-
-        return cloudbaseinit(created_user, group)
+        activate_windows = self._parser.getboolean('cloudbaseinit', 'activate_windows')
+        return cloudbaseinit(created_user, group, activate_windows)
 
     @property
     def openstack(self):

--- a/argus/resources/windows/installCBinit.ps1
+++ b/argus/resources/windows/installCBinit.ps1
@@ -1,7 +1,8 @@
 param
 (
     [string]$serviceType = 'http',
-    [string]$installer = 'CloudbaseInitSetup_Beta_x64.msi'
+    [string]$installer = 'CloudbaseInitSetup_Beta_x64.msi',
+    [string]$activation = 'False'
 )
 
 Import-Module C:\common.psm1
@@ -40,7 +41,11 @@ function Set-Service([string]$ProgramFilesDir) {
 }
 
 function Set-WindowsActivation([string]$ProgramFilesDir) {
-    $value = "activate_windows=True"
+    if ($activation -eq 'False') {
+        $value = "activate_windows=False"
+    } elseif ($activation -eq 'True') {
+        $value = "activate_windows=True"
+    }
     $path = "$ProgramFilesDir\Cloudbase Solutions\Cloudbase-Init\conf\cloudbase-init.conf"
     ((Get-Content $path) + $value) | Set-content $path
 }

--- a/argus/tests/cloud/windows/test_smoke.py
+++ b/argus/tests/cloud/windows/test_smoke.py
@@ -15,6 +15,7 @@
 
 """Smoke tests for the cloudbaseinit."""
 
+import unittest
 import pkg_resources
 
 from argus.tests import base
@@ -22,6 +23,9 @@ from argus.tests.cloud import smoke
 from argus.tests.cloud import util as test_util
 from argus import exceptions
 from argus import util
+
+
+CONFIG = util.get_config()
 
 
 def _parse_licenses(output):
@@ -63,6 +67,8 @@ class TestSmoke(smoke.TestsBaseSmoke):
 
         self.assertEqual("Running\r\n", str(stdout))
 
+    @unittest.skipUnless(CONFIG.cloudbaseinit.activate_windows,
+    	                'Needs Windows activation')
     def test_licensing(self):
         # Check that the instance OS was licensed properly.
         command = ('Get-WmiObject SoftwareLicensingProduct | '

--- a/etc/argus.conf
+++ b/etc/argus.conf
@@ -25,3 +25,4 @@ require_sysprep = True
 
 created_user = Admin
 group = Administrators
+activate_windows = True


### PR DESCRIPTION
Adds a new config value which specifies if Cloudbase-init should try to
activate the image, and also changes the licensing tests logic so that it
will only run if that field has been set as True.
