### PR TITLE
Fix local scripts path

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -215,8 +215,10 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
         self._cbinit_conf.set_conf_value(
             name="activate_windows",
             value=self._conf.cloudbaseinit.activate_windows)
+        scripts_path = "C:\\Scripts"
+        self._make_dir_if_needed(scripts_path)
         self._cbinit_conf.set_conf_value(name="local_scripts_path",
-                                         value="\Scripts")
+                                         value=scripts_path)
 
         self._cbinit_conf.set_conf_value(
             name="activate_windows",


### PR DESCRIPTION
Fixes the broken path for the local scripts and also creates the expected
folder, since this behaviour has been removed from the installCbinit
powershell script.
