### PR TITLE
Fix the issues related to APIManager.networks_client

### DIFF
--- a/argus/backends/tempest/cloud.py
+++ b/argus/backends/tempest/cloud.py
@@ -48,7 +48,7 @@ class NetworkWindowsBackend(tempest_backend.BaseWindowsTempestBackend):
         All these networks will be attached to the newly created
         instance without letting nova to handle this part.
         """
-        _networks = self._manager.compute_networks_client.list_networks()["networks"]
+        _networks = self._manager.networks_client.list_networks()["networks"]
         # Skip external/private networks.
         networks = [net["id"] for net in _networks
                     if not net["router:external"]]
@@ -131,14 +131,13 @@ class NetworkWindowsBackend(tempest_backend.BaseWindowsTempestBackend):
 
     def get_network_interfaces(self):
         """Retrieve and parse network details from the compute node."""
-        compute_networks_client = self._manager.compute_networks_client
+        ports_client = self._manager.ports_client
         networks_client = self._manager.networks_client
         subnets_client = self._manager.subnets_client
         guest_nics = []
         for network in self._networks or []:
             network_id = network["uuid"]
-            net_details = (compute_networks_client.
-                           show_network(network_id)["network"])
+            net_details = networks_client.show_network(network_id)["network"]
             nic = dict.fromkeys(util.NETWORK_KEYS)
             for subnet_id in net_details["subnets"]:
                 details = subnets_client.show_subnet(subnet_id)["subnet"]
@@ -159,7 +158,7 @@ class NetworkWindowsBackend(tempest_backend.BaseWindowsTempestBackend):
                 # There should be no conflicts because on the current
                 # architecture every instance is using its own router,
                 # subnet and network accessible only to it.
-                ports = networks_client.list_ports()["ports"]
+                ports = ports_client.list_ports()["ports"]
                 for port in ports:
                     # Select instance related ports only, with the
                     # corresponding subnet ID.

--- a/argus/backends/tempest/manager.py
+++ b/argus/backends/tempest/manager.py
@@ -76,7 +76,8 @@ class APIManager(object):
         self.interface_client = self._manager.interfaces_client
 
         # Neutron network client
-        self.networks_client = self._manager.compute_networks_client
+        self.ports_client = self._manager.ports_client
+        self.networks_client = self._manager.networks_client
         self.compute_networks_client = self._manager.compute_networks_client
         self.subnets_client = self._manager.subnets_client
 


### PR DESCRIPTION
1. Add `ports_client` to APIManager
2. Fix mapping, `APIManager.networks_client`
   needs to point to `tempest.Manager.networks_client`
3. Use `APIManager.ports_client` to list all ports
