### PR TITLE
Set the MTU for the underlying instance

### DIFF
--- a/argus/recipes/cloud/base.py
+++ b/argus/recipes/cloud/base.py
@@ -49,6 +49,16 @@ class BaseCloudbaseinitRecipe(base.BaseRecipe):
     def wait_for_boot_completion(self):
         """Wait for the instance to finish up booting."""
 
+    def set_mtu(self, interface, subinterface_name,
+                mtu_value, store_type):
+        """Sets the MTU value for the underlying instance.
+
+        Sets the MTU value in order to avoid packet loss.
+        More details about the parameters can be found below:
+        https://technet.microsoft.com/en-us/library/cc731521(v=ws.10).aspx
+        """
+        pass
+
     def execution_prologue(self):
         """Executed before any downloaded script.
 
@@ -114,6 +124,7 @@ class BaseCloudbaseinitRecipe(base.BaseRecipe):
         """
         LOG.info("Preparing instance...")
         self.wait_for_boot_completion()
+        self.set_mtu()
         self.execution_prologue()
         self.get_installation_script()
         self.install_cbinit()

--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -41,6 +41,18 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
         LOG.info("Waiting for first boot completion...")
         self._backend.remote_client.manager.wait_boot_completion()
 
+    def set_mtu(self, interface="ipv4", subinterface_name="Ethernet",
+                mtu_value=1400, store_type='active'):
+        set_mtu_cmd = ('netsh interface {interface_type} set subinterface '
+                       '"{name}" mtu={value} store={type}'
+                       .format(interface_type=interface, value=mtu_value,
+                               name=subinterface_name, type=store_type))
+        LOG.info("Setting the MTU.")
+        try:
+            self._backend.remote_client.run_command_with_retry(set_mtu_cmd)
+        except exceptions.ArgusTimeoutError as exc:
+            LOG.debug('Setting MTU failed with %r.' % exc)
+
     def execution_prologue(self):
         LOG.info("Retrieve common module for proper script execution.")
 


### PR DESCRIPTION
Sets the MTU value for the instance so that packages don't get
dropped when trying to clone or download. This is required
since we don't let neutron to force the MTU value for
the created instance.
