### PR TITLE
Add test and scenario for long hostnames

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -423,6 +423,17 @@ class CloudbaseinitKeysRecipe(CloudbaseinitHTTPRecipe,
                   "ConfigWinRMCertificateAuthPlugin")
 
 
+class CloudbaseinitLongHostname(CloudbaseinitRecipe):
+    """Recipe for testing the netbios long hostname compatibility option."""
+
+    def prepare_cbinit_config(self, service_type):
+        super(CloudbaseinitLongHostname, self).prepare_cbinit_config(
+               service_type)
+        LOG.info("Injecting netbios option in conf file.")
+        self._cbinit_conf.set_conf_value(name='netbios_host_name_compatibility',
+                                         value='False')
+
+
 class CloudbaseinitLocalScriptsRecipe(CloudbaseinitRecipe):
     """Recipe for testing local scripts return codes."""
 

--- a/argus/resources/windows/netbios_hostname
+++ b/argus/resources/windows/netbios_hostname
@@ -1,0 +1,10 @@
+Content-Type: multipart/mixed; boundary="===============1598784645116016685=="
+MIME-Version: 1.0
+
+--===============1598784645116016685==
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config"
+
+set_hostname: someverylonghostnametosetonthemachine-00

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -238,6 +238,16 @@ class TestSetHostname(base.BaseTestCase):
         self.assertEqual("newhostname", hostname.strip())
 
 
+class TestLongHostname(base.BaseTestCase):
+
+    def test_hostname_compatibility(self):
+        # Verify that the hostname is set accordingly
+        # when the netbios option is set to False
+
+        hostname = self._introspection.get_instance_hostname()
+        self.assertEqual("someverylonghostnametosetonthemachine-00", hostname)
+
+
 class TestNoError(base.BaseTestCase):
     """Test class which verifies that no traceback occurs."""
 

--- a/ci/tests.py
+++ b/ci/tests.py
@@ -77,6 +77,13 @@ class ScenarioMultipartSmokeWindowsPartTwo(BaseWindowsScenario):
     userdata = util.get_resource('windows/multipart_userdata_part_two')
 
 
+class ScenarioLongHostname(BaseWindowsScenario):
+
+    test_classes = (smoke.TestLongHostname, )
+    recipe_type = recipe.CloudbaseinitLongHostname
+    userdata = util.get_resource('windows/netbios_hostname')
+
+
 class ScenarioUserAlreadyCreated(BaseWindowsScenario):
 
     test_classes = (test_smoke.TestSmoke, )


### PR DESCRIPTION
Adds a new scenario for testing if longer hostnames are set correctly.
The behaviour is obtained by setting the 'netbios_host_name_compatibility'
option from cloudbase-init to False.
