### PR TITLE
Fix Action Manager for Windows Server 2012

### DIFF
--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -347,7 +347,8 @@ class Windows8ActionManager(WindowsActionManager):
 
 class WindowsSever2012ActionManager(Windows8ActionManager):
     def __init__(self, client, config, os_type=util.WINDOWS_SERVER_2012):
-        super(WindowsSever2012ActionManager, self).__init__(client, config)
+        super(WindowsSever2012ActionManager, self).__init__(client, config,
+                                                            os_type)
 
 
 class Windows10ActionManager(WindowsActionManager):


### PR DESCRIPTION
The Windows Server 2012 Action manager was not properly initalizated,
it had the `._os_type` properly set to `WINDOWS8`.

Signed-off-by: Micu Matei-Marius mmicu@cloudbasesolutions.com
