### PR TITLE
Replace Get-WmiObject and Get-CimInstance calls

### DIFF
--- a/argus/introspection/cloud/windows.py
+++ b/argus/introspection/cloud/windows.py
@@ -197,16 +197,20 @@ def get_cbinit_key(execute_function):
 class InstanceIntrospection(base.CloudInstanceIntrospection):
     """Utilities for introspecting a Windows instance."""
 
+    def __init__(self, remote_client):
+        super(InstanceIntrospection, self).__init__(remote_client)
+        self._cmdlet = remote_client.manager.WINDOWS_MANAGEMENT_CMDLET
+
     def get_disk_size(self):
-        cmd = ('(Get-WmiObject win32_logicaldisk | '
-               'where -Property DeviceID -Match "C:").Size')
+        cmd = ('({} win32_logicaldisk | where -Property DeviceID '
+               '-Match "C:").Size').format(self._cmdlet)
         return int(self.remote_client.run_command_verbose(
             cmd, command_type=util.POWERSHELL))
 
     def username_exists(self, username):
-        cmd = ('Get-WmiObject Win32_Account | '
-               'where -Property Name -contains {0}'
-               .format(username))
+        cmd = ('{0} Win32_Account | '
+               'where -Property Name -contains {1}'
+               .format(self._cmdlet, username))
 
         stdout = self.remote_client.run_command_verbose(
             cmd, command_type=util.POWERSHELL)

--- a/argus/tests/cloud/windows/test_smoke.py
+++ b/argus/tests/cloud/windows/test_smoke.py
@@ -50,6 +50,15 @@ def _parse_licenses(output):
 class TestSmoke(smoke.TestsBaseSmoke):
     """Test additional Windows specific behaviour."""
 
+    def __init__(self, conf, backend, recipe, introspection, *args, **kwargs):
+        super(TestSmoke, self).__init__(conf, backend, recipe, introspection,
+                                        *args, **kwargs)
+        # TODO(mmicu): We have to go through a lot of layers
+        # to accomplish our goal, we need to find a way to structure
+        # our resources better
+        self._cmdlet = (self._backend.remote_client.manager
+                        .WINDOWS_MANAGEMENT_CMDLET)
+
     def test_service_display_name(self):
         cmd = ('(Get-Service | where -Property Name '
                '-match cloudbase-init).DisplayName')
@@ -72,8 +81,8 @@ class TestSmoke(smoke.TestsBaseSmoke):
                          'Needs Windows activation')
     def test_licensing(self):
         # Check that the instance OS was licensed properly.
-        command = ('Get-WmiObject SoftwareLicensingProduct | '
-                   'where PartialProductKey | Select Name, LicenseStatus')
+        command = ('{} SoftwareLicensingProduct | where PartialProductKey '
+                   '| Select Name, LicenseStatus').format(self._cmdlet)
         stdout = self._backend.remote_client.run_command_verbose(
             command, command_type=util.POWERSHELL)
         licenses = _parse_licenses(stdout)


### PR DESCRIPTION
Because we support Windows 2008 and Nano Server we need to choose
between Common Information Model (Cim) and Windows Management
Instrumentation (Wmi) based on the OS type.

Signed-off-by: Micu Matei-Marius mmicu@cloudbasesolutions.com
