### PR TITLE
Improve the replace_install method

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -128,8 +128,13 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
 
         LOG.debug("Replace old files with the new ones.")
         cbdir = introspection.get_cbinit_dir(self._execute)
-        self._execute('xcopy /y /e /q "C:\\install\\Cloudbase-Init"'
+        self._execute('xcopy /y /e /q "C:\\install"'
                       ' "{}"'.format(cbdir), command_type=util.CMD)
+
+        # Update the new changes
+        resource_location = "windows/updateCbinit.ps1"
+        self._backend.remote_client.manager.execute_powershell_resource_script(
+            resource_location=resource_location)
 
     def replace_code(self):
         """Replace the code of cloudbaseinit."""

--- a/argus/resources/windows/updateCbinit.ps1
+++ b/argus/resources/windows/updateCbinit.ps1
@@ -1,0 +1,22 @@
+param(
+    [switch]$UpdatePythonWrappers = $True
+)
+
+# Import required PowerShell modules
+Import-Module Microsoft.PowerShell.Management
+Import-Module Microsoft.PowerShell.Utility
+Import-Module C:\common.psm1
+
+$programDir = Get-ProgramDir
+$cloudbaseInitBaseDir = Join-Path $programDir "Cloudbase Solutions\Cloudbase-Init"
+$cloudbaseInitPythonDir = Join-Path $cloudbaseInitBaseDir "Python"
+$pythonExePath = Join-Path $cloudbaseInitPythonDir "python.exe"
+
+# Update Python exe wrappers
+if ($UpdatePythonWrappers) {
+    & $pythonExePath -c "import os; import sys; from pip._vendor.distlib import scripts; specs = 'cloudbase-init = cloudbaseinit.shell:main'; scripts_path = os.path.join(os.path.dirname(sys.executable), 'Scripts'); m = scripts.ScriptMaker(None, scripts_path); m.executable = sys.executable; m.make(specs)"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to update Python exe wrappers"
+        exit 1
+    }
+}


### PR DESCRIPTION
Improves the replace_install method, used for updating
Cloudbase-init with a zip, by fixing a broken path and
also updating the newly added Cloudbase-init after copying
the files.
