### PR TITLE
Added a Upper Timeout option on the Client

### DIFF
--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -36,7 +36,8 @@ class BaseClient(object):
         self._cert_key = cert_key
 
     @abc.abstractmethod
-    def run_remote_cmd(self, command, command_type=None):
+    def run_remote_cmd(self, command, command_type=None,
+                       upper_timeout=None):
         """Run the given remote command.
 
         The command will be executed on the remote underlying server.

--- a/argus/config/ci.py
+++ b/argus/config/ci.py
@@ -21,6 +21,10 @@ from argus.config import base as conf_base
 _RESOURCES_LINK = ('https://raw.githubusercontent.com/cloudbase/'
                    'cloudbase-init-ci/master/argus/resources')
 
+IO_UPPER_TIMEOUT_MULTIPLIER = 3
+DEFAULT_UPPER_TIMEOUT = 60 * 5
+IO_UPPER_TIMEOUT = DEFAULT_UPPER_TIMEOUT * IO_UPPER_TIMEOUT_MULTIPLIER
+
 
 class ArgusOptions(conf_base.Options):
 
@@ -65,6 +69,12 @@ class ArgusOptions(conf_base.Options):
                             "checkout, clone or fetch a modified version of "
                             "Cloudbase-init, for replacing the present code "
                             "used by it."),
+            cfg.IntOpt("upper_timeout", default=DEFAULT_UPPER_TIMEOUT,
+                       help="Upper timeout for each command sent to the "
+                            "remote instance."),
+            cfg.IntOpt("io_upper_timeout", default=IO_UPPER_TIMEOUT,
+                       help="Upper timeout for each command that reads or "
+                            "writes to a file in the remote instance."),
         ]
 
     def register(self):

--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -24,9 +24,11 @@ import abc
 import six
 
 from argus import log as argus_log
+from argus import config as argus_config
 
 
 LOG = argus_log.get_logger()
+CONFIG = argus_config.CONFIG
 RETRY_COUNT = 15
 RETRY_DELAY = 10
 
@@ -48,7 +50,8 @@ class BaseRecipe(object):
         self._backend = backend
 
     def _execute(self, cmd, count=RETRY_COUNT, delay=RETRY_DELAY,
-                 command_type=None):
+                 command_type=None,
+                 upper_timeout=CONFIG.argus.upper_timeout):
         """Execute until success and return only the standard output."""
 
         # A positive exit code will trigger the failure
@@ -56,7 +59,8 @@ class BaseRecipe(object):
         # Also, if the retrying limit is reached, `ArgusTimeoutError`
         # will be raised.
         return self._backend.remote_client.run_command_with_retry(
-            cmd, count=count, delay=delay, command_type=command_type)[0]
+            cmd, count=count, delay=delay, command_type=command_type,
+            upper_timeout=upper_timeout)[0]
 
     def _execute_until_condition(self, cmd, cond, count=RETRY_COUNT,
                                  delay=RETRY_DELAY, command_type=None):

--- a/argus/unit_tests/action_manager/test_windows.py
+++ b/argus/unit_tests/action_manager/test_windows.py
@@ -161,7 +161,8 @@ class WindowsActionManagerTest(unittest.TestCase):
             test_utils.RESOURCE_LOCATION, instance_location)
         self._client.run_command_with_retry.assert_called_once_with(
             cmd, count=util.RETRY_COUNT,
-            delay=util.RETRY_DELAY, command_type=script_type)
+            delay=util.RETRY_DELAY, command_type=script_type,
+            upper_timeout=CONFIG.argus.upper_timeout)
 
     def test_execute_resource_script_bat_script(self):
         self._test_execute_resource_script(script_type=util.BAT_SCRIPT)
@@ -196,7 +197,8 @@ class WindowsActionManagerTest(unittest.TestCase):
         mock_execute_script.assert_called_once_with(
             resource_location=test_utils.RESOURCE_LOCATION,
             parameters=test_utils.PARAMETERS,
-            script_type=script_type)
+            script_type=script_type,
+            upper_timeout=CONFIG.argus.upper_timeout)
 
     def test_execute_powershell_resource_script_successful(self):
         test_method = self._action_manager.execute_powershell_resource_script
@@ -855,7 +857,8 @@ class WindowsActionManagerTest(unittest.TestCase):
                 command_type=util.CMD), test_utils.STDOUT)
             self._client.run_command_with_retry.assert_called_once_with(
                 test_utils.CMD, count=util.RETRY_COUNT,
-                delay=util.RETRY_DELAY, command_type=util.CMD)
+                delay=util.RETRY_DELAY, command_type=util.CMD,
+                upper_timeout=CONFIG.argus.upper_timeout)
 
     def test_execute(self):
         self._test_execute()


### PR DESCRIPTION
This will allow us to set a upper timeout on every command sent to the
remote instance. The curent behavior is a blocking one and we risk
getting stuck on a scenario.

Signed-off-by: Micu Matei-Marius <mmicu@cloudbasesolutions.com>