### PR TITLE
Adds Nano support for the timezone getter

### DIFF
--- a/argus/introspection/cloud/windows.py
+++ b/argus/introspection/cloud/windows.py
@@ -357,7 +357,7 @@ class InstanceIntrospection(base.CloudInstanceIntrospection):
         return files
 
     def get_timezone(self):
-        command = "[System.TimeZone]::CurrentTimeZone.StandardName"
+        command = "tzutil /g"
         stdout = self.remote_client.run_command_verbose(
             "{}".format(command), command_type=util.POWERSHELL)
         return stdout


### PR DESCRIPTION
Changes the getter for the timezone on the underlying
instance to calling the 'tzutil' utility, since it's
cross compatible across all versions of Windows(including Nano).