### PR TITLE
Add configurable option for logging file path

### DIFF
--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -27,9 +27,10 @@ from argus.action_manager import base
 from argus import config as argus_config
 from argus import exceptions
 from argus.introspection.cloud import windows as introspection
+from argus import log as argus_log
 from argus import util
 
-LOG = util.LOG
+LOG = argus_log.get_logger()
 CONFIG = argus_config.CONFIG
 
 

--- a/argus/backends/base.py
+++ b/argus/backends/base.py
@@ -19,11 +19,11 @@ import os
 import six
 
 from argus import config as argus_config
-from argus import util
+from argus import log as argus_log
 
 
 CONFIG = argus_config.CONFIG
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/argus/backends/tempest/manager.py
+++ b/argus/backends/tempest/manager.py
@@ -18,6 +18,7 @@ import os
 import tempfile
 
 from argus import exceptions
+from argus import log as argus_log
 from argus import util
 
 with util.restore_excepthook():
@@ -29,7 +30,7 @@ with util.restore_excepthook():
 OUTPUT_STATUS_OK = 200
 OUTPUT_SIZE = 128
 OUTPUT_EPSILON = int(OUTPUT_SIZE / 10)
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 
 
 @contextlib.contextmanager

--- a/argus/backends/tempest/tempest_backend.py
+++ b/argus/backends/tempest/tempest_backend.py
@@ -22,6 +22,7 @@ from argus.backends import base as base_backend
 from argus.backends.tempest import manager as api_manager
 from argus.backends import windows
 from argus import config as argus_config
+from argus import log as argus_log
 from argus import util
 
 with util.restore_excepthook():
@@ -29,7 +30,7 @@ with util.restore_excepthook():
 
 
 CONFIG = argus_config.CONFIG
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 
 # Starting size as number of lines and tolerance.
 OUTPUT_SIZE = 128

--- a/argus/client/windows.py
+++ b/argus/client/windows.py
@@ -31,10 +31,11 @@ from winrm import protocol
 from argus.action_manager.windows import get_windows_action_manager
 from argus.client import base
 from argus import exceptions
+from argus import log as argus_log
 from argus import util
 
 
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 CODEPAGE_UTF8 = 65001
 
 

--- a/argus/config/ci.py
+++ b/argus/config/ci.py
@@ -30,6 +30,9 @@ class ArgusOptions(conf_base.Options):
         super(ArgusOptions, self).__init__(config, group="argus")
         self._options = [
             cfg.StrOpt(
+                "argus_log_file", default='argus.log', required=True,
+                help="Path to the file where argus will do the logging"),
+            cfg.StrOpt(
                 "resources", default=_RESOURCES_LINK, required=True,
                 help="An url that holds the resources usually from "
                      "/argus/resources available on the web"),

--- a/argus/config_generator/windows/base.py
+++ b/argus/config_generator/windows/base.py
@@ -23,9 +23,11 @@ except ImportError:
     import io as StringIO
 
 from argus.config_generator import base
+from argus import log as argus_log
 from argus import util
 
-LOG = util.get_logger()
+
+LOG = argus_log.get_logger()
 
 
 class BaseWindowsConfig(base.BaseConfig):

--- a/argus/log.py
+++ b/argus/log.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Cloudbase Solutions Srl
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+import logging
+
+from argus import config as argus_config
+
+CONFIG = argus_config.CONFIG
+
+
+DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+
+def get_logger(name="argus",
+               format_string=DEFAULT_FORMAT,
+               logging_file=CONFIG.argus.argus_log_file):
+    """Obtain a new logger object.
+
+    The `name` parameter will be the name of the logger and `format_string`
+    will be the format it will use for logging. `logging_file` is a file
+    where the messages will be written.
+    """
+    logger = logging.getLogger(name)
+    formatter = logging.Formatter(format_string)
+
+    if not logger.handlers:
+        # If the logger wasn't obtained another time,
+        # then it shouldn't have any loggers
+
+        if logging_file:
+            file_handler = logging.FileHandler(logging_file, delay=True)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+
+    logger.setLevel(logging.DEBUG)
+    return logger

--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -23,10 +23,10 @@ import abc
 
 import six
 
-from argus import util
+from argus import log as argus_log
 
 
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 RETRY_COUNT = 15
 RETRY_DELAY = 10
 

--- a/argus/recipes/cloud/base.py
+++ b/argus/recipes/cloud/base.py
@@ -20,14 +20,13 @@ import abc
 import six
 
 from argus import config as argus_config
+from argus import log as argus_log
 from argus.recipes import base
-from argus import util
-
 
 __all__ = ('BaseCloudbaseinitRecipe', )
 
 CONFIG = argus_config.CONFIG
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -24,11 +24,12 @@ from argus import config as argus_config
 from argus.config_generator.windows import cb_init as cbinit_config
 from argus import exceptions
 from argus.introspection.cloud import windows as introspection
+from argus import log as argus_log
 from argus.recipes.cloud import base
 from argus import util
 
 CONFIG = argus_config.CONFIG
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 
 # Default values for an instance under booting step.
 COUNT = 20

--- a/argus/scenarios/base.py
+++ b/argus/scenarios/base.py
@@ -20,10 +20,9 @@ import unittest
 import six
 
 from argus import config as argus_config
-from argus import util
+from argus import log as argus_log
 
-
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 CONFIG = argus_config.CONFIG
 
 

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -23,6 +23,7 @@ import unittest
 from six.moves import urllib
 
 from argus import config as argus_config
+from argus import log as argus_log
 from argus.tests import base
 from argus.tests.cloud import util as test_util
 from argus import util
@@ -30,7 +31,7 @@ from argus import util
 DNSMASQ_NEUTRON = '/etc/neutron/dnsmasq-neutron.conf'
 
 CONFIG = argus_config.CONFIG
-LOG = util.get_logger()
+LOG = argus_log.get_logger()
 
 
 def _get_dhcp_value(key):

--- a/argus/unit_tests/test_utils.py
+++ b/argus/unit_tests/test_utils.py
@@ -17,7 +17,7 @@ import functools
 import logging as base_logging
 
 from argus import config as argus_config
-from argus import util
+from argus import log as argus_log
 
 CONFIG = argus_config.CONFIG
 
@@ -79,7 +79,7 @@ class LogSnatcher(object):
     def __init__(self, logger_name):
         self._logger_name = logger_name
         self._snatch_handler = SnatchHandler()
-        self._logger = util.get_logger()
+        self._logger = argus_log.get_logger()
         self._previous_level = self._logger.getEffectiveLevel()
 
     def __enter__(self):

--- a/argus/util.py
+++ b/argus/util.py
@@ -16,7 +16,6 @@
 import base64
 import collections
 import contextlib
-import logging
 import pkgutil
 import random
 import socket
@@ -25,6 +24,7 @@ import subprocess
 import sys
 
 import six
+
 
 RETRY_COUNT = 15
 RETRY_DELAY = 10
@@ -50,7 +50,6 @@ MAAS_SERVICE = 'maas'
 
 __all__ = (
     'decrypt_password',
-    'get_logger',
     'get_resource',
     'cached_property',
     'run_once',
@@ -59,8 +58,6 @@ __all__ = (
     'get_certificate',
 )
 
-DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-DEFAULT_LOG_FILE = 'argus.log'
 
 NETWORK_KEYS = [
     "mac",
@@ -183,31 +180,6 @@ class cached_property(object):  # pylint: disable=invalid-name
         return result
 
 
-def get_logger(name="argus",
-               format_string=DEFAULT_FORMAT,
-               logging_file=DEFAULT_LOG_FILE):
-    """Obtain a new logger object.
-
-    The `name` parameter will be the name of the logger and `format_string`
-    will be the format it will use for logging. `logging_file` is a file
-    where the messages will be written.
-    """
-    logger = logging.getLogger(name)
-    formatter = logging.Formatter(format_string)
-
-    if not logger.handlers:
-        # If the logger wasn't obtained another time,
-        # then it shouldn't have any loggers
-
-        if logging_file:
-            file_handler = logging.FileHandler(logging_file, delay=True)
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
-
-    logger.setLevel(logging.DEBUG)
-    return logger
-
-
 def rand_name(name=''):
     """Generate a random name
 
@@ -304,8 +276,6 @@ def get_command(command, command_type=None):
     modifier = COMMAND_MODIFIERS.get(command_type, lambda command: command)
     return modifier(command)
 
-
-LOG = get_logger()
 
 _BUILDS = ["Beta", "Stable", "test"]
 _ARCHES = ["x64", "x86"]


### PR DESCRIPTION
Adds a new option in the argus.conf, for specifying
the file path where argus should write the logging to.
The 'argus_log_file' option can be found in the argus section.