### PR TITLE
	 Restructure the running of powershell commands

### DIFF
--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -39,7 +39,7 @@ def wait_boot_completion(client, username):
     client.run_command_until_condition(
         wait_cmd,
         lambda stdout: stdout.strip() == username,
-        retry_count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+        retry_count=CONFIG.argus.retry_count, delay=CONFIG.argus.retry_delay,
         command_type=util.POWERSHELL)
 
 
@@ -71,8 +71,8 @@ class WindowsActionManager(base.BaseActionManager):
         cmd = ('(New-Object System.Net.WebClient).DownloadFile('
                '"{uri}","{location}")'.format(uri=uri, location=location))
         self._client.run_command_with_retry(cmd,
-                                            count=util.RETRY_COUNT,
-                                            delay=util.RETRY_DELAY,
+                                            count=CONFIG.argus.retry_count,
+                                            delay=CONFIG.argus.retry_delay,
                                             command_type=util.POWERSHELL)
 
     def download_resource(self, resource_location, location):
@@ -104,7 +104,8 @@ class WindowsActionManager(base.BaseActionManager):
         self.download_resource(resource_location, instance_location)
         cmd = '"{}" {}'.format(instance_location, parameters)
         self._client.run_command_with_retry(
-            cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+            cmd, count=CONFIG.argus.retry_count,
+            delay=CONFIG.argus.retry_delay,
             command_type=script_type, upper_timeout=upper_timeout)
 
     def execute_powershell_resource_script(
@@ -122,8 +123,8 @@ class WindowsActionManager(base.BaseActionManager):
         self.download_resource("windows/installCBinit.ps1",
                                self._INSTALL_SCRIPT)
 
-    def _execute(self, cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
-                 command_type=util.CMD,
+    def _execute(self, cmd, count=CONFIG.argus.retry_count,
+                 delay=CONFIG.argus.retry_delay, command_type=util.CMD,
                  upper_timeout=CONFIG.argus.upper_timeout):
         """Execute until succeeds and return only the standard output."""
         stdout, _, _ = self._client.run_command_with_retry(
@@ -176,7 +177,7 @@ class WindowsActionManager(base.BaseActionManager):
         LOG.info("Trying to install Cloudbase-Init.")
         installer = self._get_installer_name()
 
-        for _ in range(util.RETRY_COUNT):
+        for _ in range(CONFIG.argus.retry_count):
             for install_method in (self._run_installation_script,
                                    self._deploy_using_scheduled_task):
                 try:
@@ -226,8 +227,8 @@ class WindowsActionManager(base.BaseActionManager):
         LOG.info("Wait for the machine to finish rebooting ...")
         self.wait_boot_completion()
 
-    def git_clone(self, repo_url, location, count=util.RETRY_COUNT,
-                  delay=util.RETRY_DELAY):
+    def git_clone(self, repo_url, location, count=CONFIG.argus.retry_count,
+                  delay=CONFIG.argus.retry_delay):
         """Clone from a remote repository to a specified location.
 
         :param repo_url: The remote repository URL.
@@ -271,7 +272,8 @@ class WindowsActionManager(base.BaseActionManager):
         self._client.run_command_until_condition(
             wait_cmd,
             lambda out: out.strip() == 'Stopped',
-            retry_count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+            retry_count=CONFIG.argus.retry_count,
+            delay=CONFIG.argus.retry_delay,
             command_type=util.POWERSHELL)
 
     def check_cbinit_service(self, searched_paths=None):
@@ -287,7 +289,8 @@ class WindowsActionManager(base.BaseActionManager):
             self._client.run_command_until_condition(
                 check_cmd,
                 lambda out: out.strip() == 'True',
-                retry_count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+                retry_count=CONFIG.argus.retry_count,
+                delay=CONFIG.argus.retry_delay,
                 command_type=util.POWERSHELL)
 
     def wait_boot_completion(self):
@@ -688,7 +691,8 @@ class WindowsNanoActionManager(WindowsSever2016ActionManager):
             self.download_resource(resource_location, instance_location)
             cmd = '& "{}" {}'.format(instance_location, parameters)
             self._client.run_command_with_retry(
-                cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+                cmd, count=CONFIG.argus.retry_count,
+                delay=CONFIG.argus.retry_delay,
                 command_type=util.POWERSHELL, upper_timeout=upper_timeout)
 
 
@@ -715,7 +719,7 @@ def _is_nanoserver(client):
 
     cmd = r'Test-Path "{}"'.format(server_level_key)
     path_exists, _, _ = client.run_command_with_retry(
-        cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+        cmd, count=CONFIG.argus.retry_count, delay=CONFIG.argus.retry_delay,
         command_type=util.POWERSHELL)
 
     if path_exists == "False":
@@ -723,7 +727,7 @@ def _is_nanoserver(client):
 
     cmd = r'(Get-ItemProperty "{}").NanoServer'.format(server_level_key)
     nanoserver_property, _, _ = client.run_command_with_retry(
-        cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+        cmd, count=CONFIG.argus.retry_count, delay=CONFIG.argus.retry_delay,
         command_type=util.POWERSHELL)
 
     return len(nanoserver_property) > 0 and nanoserver_property[0] == "1"
@@ -747,7 +751,7 @@ def _get_product_type(client, major_version):
     cmd = r"({} -Class Win32_OperatingSystem).producttype".format(cmdlet)
 
     product_type, _, _ = client.run_command_with_retry(
-        cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
+        cmd, count=CONFIG.argus.retry_count, delay=CONFIG.argus.retry_delay,
         command_type=util.POWERSHELL)
     return util.get_int_from_str(product_type.strip())
 

--- a/argus/client/windows.py
+++ b/argus/client/windows.py
@@ -116,7 +116,7 @@ class WinRemoteClient(base.BaseClient):
             return util.sanitize_command_output(stdout), stderr, exit_code
         except multiprocessing.TimeoutError:
             raise exceptions.ArgusTimeoutError(
-                "The upper Timeout what reached!")
+                "The command '{cmd}' has timed out.".format(cmd=bare_command))
         finally:
             thread_pool.terminate()
             protocol_client.cleanup_command(shell_id, command_id)
@@ -235,8 +235,8 @@ class WinRemoteClient(base.BaseClient):
         LOG.info("The exit code of the command was: %s", exit_code)
         return stdout
 
-    def run_command_with_retry(self, cmd, count=util.RETRY_COUNT,
-                               delay=util.RETRY_DELAY,
+    def run_command_with_retry(self, cmd, count=CONFIG.argus.retry_count,
+                               delay=CONFIG.argus.retry_delay,
                                command_type=util.POWERSHELL,
                                upper_timeout=CONFIG.argus.upper_timeout):
         """Run the given `cmd` until succeeds.
@@ -275,8 +275,8 @@ class WinRemoteClient(base.BaseClient):
                 time.sleep(delay)
 
     def run_command_until_condition(self, cmd, cond,
-                                    retry_count=util.RETRY_COUNT,
-                                    delay=util.RETRY_DELAY,
+                                    retry_count=CONFIG.argus.retry_count,
+                                    delay=CONFIG.argus.retry_delay,
                                     command_type=util.POWERSHELL,
                                     upper_timeout=CONFIG.argus.upper_timeout):
         """Run the given `cmd` until a condition `cond` occurs.

--- a/argus/config/ci.py
+++ b/argus/config/ci.py
@@ -75,6 +75,11 @@ class ArgusOptions(conf_base.Options):
             cfg.IntOpt("io_upper_timeout", default=IO_UPPER_TIMEOUT,
                        help="Upper timeout for each command that reads or "
                             "writes to a file in the remote instance."),
+            cfg.IntOpt("retry_count", default=15,
+                       help="The retry counts for a failing command."),
+            cfg.IntOpt("retry_delay", default=10,
+                       help="The number of seconds between the retries "
+                            " of a failed command."),
         ]
 
     def register(self):

--- a/argus/config_generator/windows/cb_init.py
+++ b/argus/config_generator/windows/cb_init.py
@@ -16,9 +16,12 @@ import ntpath
 
 import six
 
+from argus import config as argus_config
 from argus.config_generator.windows import base
 from argus.introspection.cloud import windows as introspect
 from argus import util
+
+CONFIG = argus_config.CONFIG
 
 
 class BasePopulatedCBInitConfig(base.BaseWindowsConfig):
@@ -42,8 +45,8 @@ class BasePopulatedCBInitConfig(base.BaseWindowsConfig):
             self.conf.add_section(section)
         self.conf.set(section, name, value)
 
-    def _execute(self, cmd, count=util.RETRY_COUNT, delay=util.RETRY_DELAY,
-                 command_type=None):
+    def _execute(self, cmd, count=CONFIG.argus.retry_count,
+                 delay=CONFIG.argus.retry_delay, command_type=None):
         """Execute until success and return only the standard output
 
         A positive exit code will trigger the failure

--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -23,8 +23,8 @@ import abc
 
 import six
 
-from argus import log as argus_log
 from argus import config as argus_config
+from argus import log as argus_log
 
 
 LOG = argus_log.get_logger()

--- a/argus/util.py
+++ b/argus/util.py
@@ -26,9 +26,6 @@ import sys
 import six
 
 
-RETRY_COUNT = 15
-RETRY_DELAY = 10
-
 CMD = "cmd"
 BAT_SCRIPT = "bat"
 POWERSHELL = "powershell"
@@ -238,7 +235,7 @@ def _get_command_powershell(command):
     if six.PY3:
         encoded = encoded.decode()
 
-    command = ("powershell -Noninteractive -NoLogo"
+    command = ("powershell -NonInteractive -NoLogo"
                " -EncodedCommand {}").format(encoded)
 
     return command
@@ -246,17 +243,15 @@ def _get_command_powershell(command):
 
 def _get_command_powershell_script(command):
     """Return a valid CMD command that runs a powershell script."""
-    return "powershell -File {}".format(command)
+    return "powershell -NonInteractive -NoLogo -File {}".format(command)
 
 
-def _get_cmd_with_privileges(policy=None):
+def _get_cmd_with_privileges(policy="RemoteSigned"):
     """Factory function that runs powershell scripts with a specific Policy."""
-    if not policy:
-        return _get_command_powershell_script
 
     def _get_cmd(command):
-        return "powershell -ExecutionPolicy {} -File {}".format(policy,
-                                                                command)
+        return ("powershell -NonInteractive -NoLogo -ExecutionPolicy "
+                "{} -File {}".format(policy, command))
     return _get_cmd
 
 


### PR DESCRIPTION
Adds a few other arguments required for properly running
powershell commands or scripts.
It also moves the retry_count and retry_delay to the config, to make
it easier for customization.
And also fixes an exception message for when commands timeout.