### PR TITLE
Add the ability to log from a specific scenario

### DIFF
--- a/argus/action_manager/base.py
+++ b/argus/action_manager/base.py
@@ -13,9 +13,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+
 import abc
 
 import six
+
+from argus import log as argus_log
+
+LOG = argus_log.LOG
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -31,6 +36,12 @@ class BaseActionManager(object):
     def __init__(self, client, os_type):
         self._client = client
         self._os_type = os_type
+
+        self._config_os_type_on_logger()
+
+    def _config_os_type_on_logger(self):
+        """Set the os type on the logger."""
+        LOG.extra["os_type"] = self._os_type
 
     @abc.abstractmethod
     def download(self, uri, location):

--- a/argus/action_manager/base.py
+++ b/argus/action_manager/base.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
 import abc
 
 import six
@@ -40,8 +39,11 @@ class BaseActionManager(object):
         self._config_os_type_on_logger()
 
     def _config_os_type_on_logger(self):
-        """Set the os type on the logger."""
+        """Set the OS type on the logger."""
+        LOG.debug("Update the logger with the following OS version: %s",
+                  self._os_type)
         LOG.extra["os_type"] = self._os_type
+        argus_log.add_new_handler(LOG)
 
     @abc.abstractmethod
     def download(self, uri, location):

--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -30,7 +30,7 @@ from argus.introspection.cloud import windows as introspection
 from argus import log as argus_log
 from argus import util
 
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 CONFIG = argus_config.CONFIG
 
 

--- a/argus/backends/base.py
+++ b/argus/backends/base.py
@@ -23,7 +23,7 @@ from argus import log as argus_log
 
 
 CONFIG = argus_config.CONFIG
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/argus/backends/tempest/manager.py
+++ b/argus/backends/tempest/manager.py
@@ -30,7 +30,7 @@ with util.restore_excepthook():
 OUTPUT_STATUS_OK = 200
 OUTPUT_SIZE = 128
 OUTPUT_EPSILON = int(OUTPUT_SIZE / 10)
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 
 @contextlib.contextmanager

--- a/argus/backends/tempest/tempest_backend.py
+++ b/argus/backends/tempest/tempest_backend.py
@@ -30,7 +30,7 @@ with util.restore_excepthook():
 
 
 CONFIG = argus_config.CONFIG
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 # Starting size as number of lines and tolerance.
 OUTPUT_SIZE = 128

--- a/argus/client/windows.py
+++ b/argus/client/windows.py
@@ -38,7 +38,7 @@ from argus import log as argus_log
 from argus import util
 
 
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 CONFIG = argus_config.CONFIG
 CODEPAGE_UTF8 = 65001
 THREADS = 1

--- a/argus/config/ci.py
+++ b/argus/config/ci.py
@@ -80,6 +80,8 @@ class ArgusOptions(conf_base.Options):
             cfg.IntOpt("retry_delay", default=10,
                        help="The number of seconds between the retries "
                             " of a failed command."),
+            cfg.BoolOpt("log_each_scenario", default=False,
+                        help="Create individual log files for each scenario."),
         ]
 
     def register(self):

--- a/argus/config_generator/windows/base.py
+++ b/argus/config_generator/windows/base.py
@@ -27,7 +27,7 @@ from argus import log as argus_log
 from argus import util
 
 
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 
 class BaseWindowsConfig(base.BaseConfig):

--- a/argus/log.py
+++ b/argus/log.py
@@ -19,7 +19,8 @@ from argus import config as argus_config
 CONFIG = argus_config.CONFIG
 
 
-DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+DEFAULT_FORMAT = ('%(asctime)s - %(name)s - %(scenario)s - '
+                  '%(os_type)s - %(levelname)s - %(message)s')
 
 
 def get_logger(name="argus",
@@ -31,6 +32,8 @@ def get_logger(name="argus",
     will be the format it will use for logging. `logging_file` is a file
     where the messages will be written.
     """
+    extra = {"scenario": "none", "os_type": "unknown"}
+
     logger = logging.getLogger(name)
     formatter = logging.Formatter(format_string)
 
@@ -44,4 +47,8 @@ def get_logger(name="argus",
             logger.addHandler(file_handler)
 
     logger.setLevel(logging.DEBUG)
-    return logger
+    logger_adapter = logging.LoggerAdapter(logger, extra)
+    return logger_adapter
+
+
+LOG = get_logger()

--- a/argus/log.py
+++ b/argus/log.py
@@ -12,6 +12,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
+import os
 import logging
 
 from argus import config as argus_config
@@ -19,8 +21,8 @@ from argus import config as argus_config
 CONFIG = argus_config.CONFIG
 
 
-DEFAULT_FORMAT = ('%(asctime)s - %(name)s - %(scenario)s - '
-                  '%(os_type)s - %(levelname)s - %(message)s')
+DEFAULT_FORMAT = ('%(scenario)s - %(os_type)s - %(asctime)s - %(name)s - '
+                  '%(levelname)s - %(message)s')
 
 
 def get_logger(name="argus",
@@ -32,7 +34,7 @@ def get_logger(name="argus",
     will be the format it will use for logging. `logging_file` is a file
     where the messages will be written.
     """
-    extra = {"scenario": "none", "os_type": "unknown"}
+    extra = {"scenario": "unknown", "os_type": "unknown"}
 
     logger = logging.getLogger(name)
     formatter = logging.Formatter(format_string)
@@ -49,6 +51,33 @@ def get_logger(name="argus",
     logger.setLevel(logging.DEBUG)
     logger_adapter = logging.LoggerAdapter(logger, extra)
     return logger_adapter
+
+
+def set_scenario_name(log, name):
+    """Set a scenario name for a given logger object.
+
+    :param log: A logging handler.
+    """
+    log.extra["scenario"] = name
+
+
+def add_new_handler(log, format_string=DEFAULT_FORMAT):
+    """Add a new FileHandler if it is specified in config
+
+    :param log: A logging handler.
+    """
+    if CONFIG.argus.log_each_scenario:
+        directory = os.path.dirname(os.path.abspath(
+            CONFIG.argus.argus_log_file))
+        logging_file_name = "argus-{}-{}.log".format(
+            log.extra.get("scenario", ""), log.extra.get("os_type", ""))
+        logging_file = os.path.join(directory, logging_file_name)
+
+        formatter = logging.Formatter(format_string)
+        file_handler = logging.FileHandler(logging_file, delay=True)
+        file_handler.setFormatter(formatter)
+
+        log.logger.addHandler(file_handler)
 
 
 LOG = get_logger()

--- a/argus/recipes/base.py
+++ b/argus/recipes/base.py
@@ -27,7 +27,7 @@ from argus import config as argus_config
 from argus import log as argus_log
 
 
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 CONFIG = argus_config.CONFIG
 RETRY_COUNT = 15
 RETRY_DELAY = 10

--- a/argus/recipes/cloud/base.py
+++ b/argus/recipes/cloud/base.py
@@ -26,7 +26,7 @@ from argus.recipes import base
 __all__ = ('BaseCloudbaseinitRecipe', )
 
 CONFIG = argus_config.CONFIG
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -31,7 +31,7 @@ from argus.recipes.cloud import base
 from argus import util
 
 CONFIG = argus_config.CONFIG
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 # Default values for an instance under booting step.
 COUNT = 20

--- a/argus/scenarios/base.py
+++ b/argus/scenarios/base.py
@@ -133,7 +133,7 @@ class BaseScenario(unittest.TestCase):
         LOG.info("Running scenario %s", cls.__name__)
 
         # Populate the LOG handler
-        LOG.extra["scenario"] = cls.__name__
+        argus_log.set_scenario_name(LOG, cls.__name__)
 
         # Create output_directory when given
         if CONFIG.argus.output_directory:

--- a/argus/scenarios/base.py
+++ b/argus/scenarios/base.py
@@ -22,7 +22,7 @@ import six
 from argus import config as argus_config
 from argus import log as argus_log
 
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 CONFIG = argus_config.CONFIG
 
 
@@ -131,6 +131,10 @@ class BaseScenario(unittest.TestCase):
         # so we're just disabling the errors for now.
 
         LOG.info("Running scenario %s", cls.__name__)
+
+        # Populate the LOG handler
+        LOG.extra["scenario"] = cls.__name__
+
         # Create output_directory when given
         if CONFIG.argus.output_directory:
             try:

--- a/argus/tests/cloud/smoke.py
+++ b/argus/tests/cloud/smoke.py
@@ -31,7 +31,7 @@ from argus import util
 DNSMASQ_NEUTRON = '/etc/neutron/dnsmasq-neutron.conf'
 
 CONFIG = argus_config.CONFIG
-LOG = argus_log.get_logger()
+LOG = argus_log.LOG
 
 
 def _get_dhcp_value(key):

--- a/argus/unit_tests/action_manager/test_windows.py
+++ b/argus/unit_tests/action_manager/test_windows.py
@@ -1468,20 +1468,27 @@ class ActionManagerTest(unittest.TestCase):
         if isinstance(windows_type, dict):
             windows_type = windows_type[is_nanoserver]
 
-        log_message = ("We got the OS type {} because we have the major "
-                       "Version : {}, the minor version {}, the product Type :"
-                       " {}, and IsNanoserver: {}").format(windows_type,
-                                                           major_version,
-                                                           minor_version,
-                                                           product_type,
-                                                           is_nanoserver)
+        log_message_booting = ("Waiting for boot completion in order to "
+                               "select an Action Manager ...")
+
+        log_message_action_manager_type = (
+            "We got the OS type {} because we have the major "
+            "Version : {}, the minor version {}, the product Type"
+            " : {}, and IsNanoserver: {}").format(windows_type, major_version,
+                                                  minor_version, product_type,
+                                                  is_nanoserver)
+
+        log_message_log_update = ("Update the logger with the following OS"
+                                  " version: {}").format(windows_type)
         with test_utils.LogSnatcher('argus.action_manager.windows'
                                     '.get_windows_action_manager') as snatcher:
             self.assertTrue(isinstance(
                 action_manager.get_windows_action_manager(self._client),
                 action_manager.WindowsActionManagers[windows_type]))
-
-            self.assertEqual(snatcher.output[-1:], [log_message])
+            self.assertEqual(snatcher.output,
+                             [log_message_booting,
+                              log_message_action_manager_type,
+                              log_message_log_update])
 
     def test_get_windows_action_manager_wait_boot_completion_exc(self):
         self._test_get_windows_action_manager(

--- a/argus/unit_tests/test_utils.py
+++ b/argus/unit_tests/test_utils.py
@@ -88,17 +88,17 @@ class LogSnatcher(object):
     def __init__(self, logger_name):
         self._logger_name = logger_name
         self._snatch_handler = SnatchHandler()
-        self._logger = argus_log.get_logger()
-        self._previous_level = self._logger.getEffectiveLevel()
+        self._logger = argus_log.LOG
+        self._previous_level = self._logger.logger.getEffectiveLevel()
 
     def __enter__(self):
-        self._logger.setLevel(base_logging.DEBUG)
-        self._logger.handlers.append(self._snatch_handler)
+        self._logger.logger.setLevel(base_logging.DEBUG)
+        self._logger.logger.handlers.append(self._snatch_handler)
         return self
 
     def __exit__(self, *args):
-        self._logger.handlers.remove(self._snatch_handler)
-        self._logger.setLevel(self._previous_level)
+        self._logger.logger.handlers.remove(self._snatch_handler)
+        self._logger.logger.setLevel(self._previous_level)
 
 
 class ConfPatcher(object):


### PR DESCRIPTION
When running tests in parallel we can't distinguish what scenario logged
something. With this patch the all the loggin statemats will contain the
scenario that loggs them.

Signed-off-by: Micu Matei-Marius <mmicu@cloudbasesolutions.com>