### PR TITLE
Removes the double activate option from the config

### DIFF
--- a/argus/config/cloudbaseinit.py
+++ b/argus/config/cloudbaseinit.py
@@ -36,6 +36,9 @@ class CloudbaseInitOptions(conf_base.Options):
             cfg.BoolOpt("activate_windows", default=False, required=True,
                         help="Specifies whether Cloudbase-init will try to "
                              "run the activation plugin on the instance."),
+            cfg.BoolOpt("check_latest_version", default=True, required=False,
+                        help="Specifies whether Cloudbase-init should try to "
+                             "check if there is a newer version of it.")
         ]
 
     def register(self):

--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -280,8 +280,8 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
                                          value=scripts_path)
 
         self._cbinit_conf.set_conf_value(
-            name="activate_windows",
-            value=CONFIG.cloudbaseinit.activate_windows)
+            name="check_latest_version",
+            value=CONFIG.cloudbaseinit.check_latest_version)
 
         self._backend.remote_client.manager.prepare_config(
             self._cbinit_conf, self._cbinit_unattend_conf)


### PR DESCRIPTION
Removes redundant code block that sets the activation
of Windows twice in the config file.
Also adds a configurable option to check for the latest
version of Cloudbase-init.