### PR TITLE
Fixes the CloudbaseinitWinrmRecipe

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -480,10 +480,14 @@ class CloudbaseinitWinrmRecipe(CloudbaseinitCreateUserRecipe):
               self).prepare_cbinit_config(service_type)
         self._cbinit_conf.set_conf_value(
             name="plugins",
-            value="cloudbaseinit.plugins.windows.winrmcertificateauth."
-                  "ConfigWinRMCertificateAuthPlugin,"
+            value="cloudbaseinit.plugins.windows.createuser."
+                  "CreateUserPlugin,"
+                  "cloudbaseinit.plugins.windows.setuserpassword."
+                  "SetUserPasswordPlugin,"
                   "cloudbaseinit.plugins.windows.winrmlistener."
-                  "ConfigWinRMListenerPlugin")
+                  "ConfigWinRMListenerPlugin,"
+                  "cloudbaseinit.plugins.windows.winrmcertificateauth."
+                  "ConfigWinRMCertificateAuthPlugin")
 
 
 class CloudbaseinitHTTPRecipe(CloudbaseinitMockServiceRecipe):


### PR DESCRIPTION
The recipe used for the WinrmListenerPlugin scenario will fail since there
is no user on which a listener can be created on.
This adds the required user creation plugins in order for the scenario to work.