### PR TITLE
Fix open_shell

### DIFF
--- a/argus/client/windows.py
+++ b/argus/client/windows.py
@@ -85,6 +85,11 @@ class WinRemoteClient(base.BaseClient):
         self.manager = get_windows_action_manager(self)
 
     @staticmethod
+    def exec_with_retry(cmd):
+        return util.exec_with_retry(cmd, CONFIG.argus.retry_count,
+                                    CONFIG.argus.retry_delay)
+
+    @staticmethod
     def _run_command(protocol_client, shell_id, command,
                      command_type=util.POWERSHELL,
                      upper_timeout=CONFIG.argus.upper_timeout):
@@ -124,7 +129,9 @@ class WinRemoteClient(base.BaseClient):
     def _run_commands(self, commands, commands_type=util.POWERSHELL,
                       upper_timeout=CONFIG.argus.upper_timeout):
         protocol_client = self._get_protocol()
-        shell_id = protocol_client.open_shell(codepage=CODEPAGE_UTF8)
+        shell_id = self.exec_with_retry(lambda: (protocol_client.open_shell(
+            codepage=CODEPAGE_UTF8)))
+
         try:
             results = [self._run_command(protocol_client, shell_id, command,
                                          commands_type, upper_timeout)

--- a/argus/config/mock_cloudstack.py
+++ b/argus/config/mock_cloudstack.py
@@ -17,7 +17,6 @@
 from oslo_config import cfg
 
 from argus.config import base as config_base
-from argus import util
 
 
 class MockCloudStackOptions(config_base.Options):
@@ -30,7 +29,7 @@ class MockCloudStackOptions(config_base.Options):
         self._options = [
             cfg.StrOpt(
                 "metadata_base_url",
-                default="http://%s/cloudstack" % util.get_local_ip(),
+                default="http://127.0.0.1/cloudstack",
                 help="The base URL where the service looks for metadata"),
             cfg.BoolOpt(
                 "https_allow_insecure", default=False,

--- a/argus/config/mock_ec2.py
+++ b/argus/config/mock_ec2.py
@@ -17,7 +17,6 @@
 from oslo_config import cfg
 
 from argus.config import base as config_base
-from argus import util
 
 
 class MockEC2Options(config_base.Options):
@@ -29,7 +28,7 @@ class MockEC2Options(config_base.Options):
         self._options = [
             cfg.StrOpt(
                 "metadata_base_url",
-                default="http://%s" % util.get_local_ip(),
+                default="http://127.0.0.1",
                 help="The base URL where the service looks for metadata"),
             cfg.BoolOpt(
                 "add_metadata_private_ip_route", default=True,

--- a/argus/config/mock_maas.py
+++ b/argus/config/mock_maas.py
@@ -17,7 +17,6 @@
 from oslo_config import cfg
 
 from argus.config import base as config_base
-from argus import util
 
 
 class MockMAASOptions(config_base.Options):
@@ -29,7 +28,7 @@ class MockMAASOptions(config_base.Options):
         self._options = [
             cfg.StrOpt(
                 "metadata_base_url",
-                default="http://%s/" % util.get_local_ip(),
+                default="http://127.0.0.1/",
                 help="The base URL for MaaS metadata"),
             cfg.StrOpt(
                 "oauth_consumer_key", default="",

--- a/argus/config/mock_openstack.py
+++ b/argus/config/mock_openstack.py
@@ -17,7 +17,6 @@
 from oslo_config import cfg
 
 from argus.config import base as config_base
-from argus import util
 
 
 class MockOpenStackOptions(config_base.Options):
@@ -30,7 +29,7 @@ class MockOpenStackOptions(config_base.Options):
         self._options = [
             cfg.StrOpt(
                 "metadata_base_url",
-                default="http://%s/" % util.get_local_ip(),
+                default="http://127.0.0.1/",
                 help="The base URL where the service looks for metadata"),
             cfg.BoolOpt(
                 "add_metadata_private_ip_route", default=True,

--- a/argus/util.py
+++ b/argus/util.py
@@ -22,9 +22,11 @@ import socket
 import struct
 import subprocess
 import sys
+import time
 
 import six
 
+from argus import exceptions
 
 CMD = "cmd"
 BAT_SCRIPT = "bat"
@@ -68,6 +70,21 @@ NETWORK_KEYS = [
     "dns6",
     "dhcp"
 ]
+
+
+def exec_with_retry(action, retry_count, retry_count_interval):
+    i = 0
+    while True:
+        try:
+            return action()
+        except Exception:
+            if i < retry_count:
+                i += 1
+                time.sleep(retry_count_interval)
+            else:
+                raise exceptions.ArgusTimeoutError(
+                    "{!r} failed too many times."
+                    .format(action))
 
 
 def get_int_from_str(content):


### PR DESCRIPTION
Improves the open_shell behaviour by adding a try/catch inside and
looping, until the shell on the underlying instance has been successfully
opened.
Also adds different executables for 32bit and 64bit versions of Windows,
since Windows Nano has been stripped of syswow64 and it isn't able
to run 32bit executable versions.