### PR TITLE
Add Test-path condition in powershell code blocks

### DIFF
--- a/argus/action_manager/windows.py
+++ b/argus/action_manager/windows.py
@@ -363,7 +363,8 @@ class WindowsActionManager(base.BaseActionManager):
             raise exceptions.ArgusCLIError("Invalid Path '{}'.".format(path))
 
         LOG.debug("Remove file %s", path)
-        cmd = "Remove-Item -Force -Path '{path}'".format(path=path)
+        cmd = ("If (Test-Path -Path '{path}') {{Remove-Item -Force "
+               "-Path '{path}'}}".format(path=path))
         self._client.run_command_with_retry(cmd, command_type=util.POWERSHELL)
 
     def rmdir(self, path):
@@ -372,8 +373,8 @@ class WindowsActionManager(base.BaseActionManager):
             raise exceptions.ArgusCLIError("Invalid Path '{}'.".format(path))
 
         LOG.debug("Remove directory  %s", path)
-        cmd = "Remove-Item -Force -Recurse -Path '{path}'".format(path=path)
-        self._client.run_command_with_retry(cmd, command_type=util.POWERSHELL)
+        cmd = ("IF EXIST '{path}' (RD /S /Q '{path}')".format(path=path))
+        self._client.run_command_with_retry(cmd, command_type=util.CMD)
 
     def _exists(self, path, path_type):
         """Check if the path exists and it has the specified type.

--- a/argus/unit_tests/action_manager/test_windows.py
+++ b/argus/unit_tests/action_manager/test_windows.py
@@ -397,8 +397,8 @@ class WindowsActionManagerTest(unittest.TestCase):
     def _test_remove(self, mock_is_file, mock_exists,
                      is_file=True, exists=True,
                      is_file_exc=None, exists_exc=None, run_exc=None):
-        cmd = "Remove-Item -Force -Path '{path}'".format(path=test_utils.PATH)
-
+        cmd = ("If (Test-Path -Path '{path}') {{Remove-Item -Force "
+               "-Path '{path}'}}".format(path=test_utils.PATH))
         mock_exists.return_value = exists
         mock_is_file.return_value = is_file
 
@@ -454,8 +454,8 @@ class WindowsActionManagerTest(unittest.TestCase):
     def _test_rmdir(self, mock_is_dir, mock_exists,
                     is_dir=True, exists=True,
                     is_dir_exc=None, exists_exc=None, run_exc=None):
-        cmd = "Remove-Item -Force -Recurse -Path '{path}'".format(
-            path=test_utils.PATH)
+        cmd = ("IF EXIST '{path}' (RD /S /Q"
+               " '{path}')".format(path=test_utils.PATH))
 
         mock_exists.return_value = exists
         mock_is_dir.return_value = is_dir
@@ -485,7 +485,7 @@ class WindowsActionManagerTest(unittest.TestCase):
 
         self._action_manager.rmdir(test_utils.PATH)
         self._client.run_command_with_retry.assert_called_once_with(
-            cmd, command_type=util.POWERSHELL)
+            cmd, command_type=util.CMD)
 
     def test_rmdir_successful(self):
         self._test_rmdir()


### PR DESCRIPTION
Adds a Test-Path, before trying to remove any items, so that
the command will not retry and fail in case the item was already deleted.