### PR TITLE
Fix requirements installation when changed

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -226,6 +226,11 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
                                      location=_CBINIT_TARGET_LOCATION),
                       command_type=util.CMD)
 
+        command = '"{folder}" -m pip install {location}'
+        self._execute(command.format(folder=python,
+                                     location=_CBINIT_TARGET_LOCATION),
+                      command_type=util.CMD)
+
     def pre_sysprep(self):
         # Patch the installation of Cloudbase-Init in order to create
         # a file when the execution ends. We're doing this instead of

--- a/argus/unit_tests/recipes/cloud/test_windows.py
+++ b/argus/unit_tests/recipes/cloud/test_windows.py
@@ -313,7 +313,7 @@ class TestCloudbaseinitRecipe(unittest.TestCase):
                     python_dir, "Lib", "site-packages", "cloudbaseinit")
                 self.assertEqual(mock_execute.call_count, 1)
             else:
-                self.assertEqual(mock_execute.call_count, 4)
+                self.assertEqual(mock_execute.call_count, 5)
                 self.assertEqual(mock_join.call_count, 2)
 
     def test_replace_code_no_git(self):


### PR DESCRIPTION
In case the requirements file is changed, cloudbase-init has to be
installed via pip. This is also a better practice than just
copying the cloudbase-init code content to the python site-packages
directory.