### PR TITLE
Pin pylint to 1.6.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps = flake8
 
 [testenv:pylint]
 commands = pylint argus --rcfile={toxinidir}/.pylintrc {posargs}
-deps = pylint
+deps = pylint==1.6.5
 
 [testenv:cover]
 commands = nosetests argus/unit_tests {posargs:--with-coverage}


### PR DESCRIPTION
Pylint 1.7.1 comes with a more rules,
so the pylint run will fail with the current code.
To do(avladu): fix the pylint 1.7.1 run.