### PR TITLE
Add upper constraints when installing packages

### DIFF
--- a/argus/recipes/cloud/windows.py
+++ b/argus/recipes/cloud/windows.py
@@ -226,13 +226,16 @@ class CloudbaseinitRecipe(base.BaseCloudbaseinitRecipe):
 
         # Auto-install packages from the new requirements.txt
         python = ntpath.join(python_dir, "python.exe")
-        command = '"{folder}" -m pip install -r {location}\\requirements.txt'
+        command = ('"{folder}" -m pip install -c {constraints} -r '
+                   '{location}\\requirements.txt')
         self._execute(command.format(folder=python,
+                                     constraints=util.UPPER_CONSTRAINTS,
                                      location=_CBINIT_TARGET_LOCATION),
                       command_type=util.CMD)
 
-        command = '"{folder}" -m pip install {location}'
+        command = '"{folder}" -m pip install -c {constraints} {location}'
         self._execute(command.format(folder=python,
+                                     constraints=util.UPPER_CONSTRAINTS,
                                      location=_CBINIT_TARGET_LOCATION),
                       command_type=util.CMD)
 

--- a/argus/util.py
+++ b/argus/util.py
@@ -69,6 +69,9 @@ SAN_POLICY_ONLINE_STR = 'OnlineAll'
 SAN_POLICY_OFFLINE_STR = 'OfflineAll'
 SAN_POLICY_OFFLINE_SHARED_STR = 'OfflineShared'
 
+UPPER_CONSTRAINTS = ("https://git.openstack.org/cgit/openstack/requirements"
+                     "/plain/upper-constraints.txt")
+
 __all__ = (
     'decrypt_password',
     'get_logger',


### PR DESCRIPTION
Enforce upper packages when installing Cloudbase-Init and the required
packages